### PR TITLE
Feature: additions 09/2019

### DIFF
--- a/lib/class-pixelssite.php
+++ b/lib/class-pixelssite.php
@@ -112,6 +112,11 @@ class PixelsSite extends \TimberSite {
 		}
 
 		/**
+		 * Setup theme slug for textdomain context
+		 */
+		$context['textdomain'] = 'pixels-text-domain';
+
+		/**
 		 * Sets the privacy policy page, if it exists.
 		 */
 		if ( function_exists( 'get_privacy_policy_url' ) ) {

--- a/views/components/site-footer/site-footer.twig
+++ b/views/components/site-footer/site-footer.twig
@@ -10,6 +10,6 @@
   <section class="site-footer-credits container text-center">
     <a href="{{ privacy }}">{{ __('Privacy policy', 'pixels-text-domain') }}</a>
     {{ __('&copy; %1$s %2$s.', 'pixels-text-domain')|format(("now"|date('Y')), 'Company') }}
-    {{ __('Crafted by <a href="https://pixels.fi" rel="nofollow" target="_blank">Pixels</a>.', 'pixels-text-domain') }}
+    {{ __('Crafted by <a href="https://pixels.fi" target="_blank">Pixels</a>.', 'pixels-text-domain') }}
   </section>
 </footer>


### PR DESCRIPTION
- Add theme-slug (textdomain) to Timber context. Usable through variable "textdomain". Resolves #60 
- Remove no-follow from "Crafted by Pixels" footer link.