### PR TITLE
Main.js: add structure for common DOM bindings

### DIFF
--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -1,11 +1,48 @@
-// Import styles
+// Styles.
 import '../styles/main.scss'
 
-import $ from 'jquery';
+// Imports.
+import $ from 'jquery' // eslint-disable-line
+import 'bootstrap'
 
-// Import Bootstrap.
-import 'bootstrap';
+const pixelsThemeApp = function() {  
 
-$(function() {
+  // Page load actions.
+  const init = () => {
 
-});
+  }
+
+  // Scroll actions.
+  const scroll = () => {
+
+  }
+
+  // Resize screen actions.
+  const resize = () => {
+
+  }
+
+  /* Functions */
+
+  // Exports to DOM binds.
+  return {init:init,scroll:scroll,resize:resize}
+}()
+
+
+/**
+ * DOM listener binds
+ * --> Init
+ * --> Scroll
+ * --> Resize
+ */
+document.addEventListener('DOMContentLoaded', () => {
+  pixelsThemeApp.init()
+})
+
+window.addEventListener('scroll', () => {
+  pixelsThemeApp.scroll();
+})
+
+window.addEventListener('resize', () => {
+  pixelsThemeApp.resize();
+})


### PR DESCRIPTION
Replaced main.js structure with new base. The old one was basically just jQuery document.ready().

- Add pixelsThemeApp structure for global site JS
- Add DOM binds to init, scroll and resize events