### PR TITLE
Make vimeo/youtube embeds responsive

### DIFF
--- a/assets/scripts/common/video-embeds.js
+++ b/assets/scripts/common/video-embeds.js
@@ -1,0 +1,16 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const embed_videos = document.querySelectorAll( 'iframe[src*="youtube"], iframe[src*="vimeo"]' );
+
+    embed_videos.forEach( video => {
+        
+        // Remove enforced height & width
+        video.removeAttribute('height');
+        video.removeAttribute('width');
+
+        // Wrap video html in wrapper
+        let wrapper = document.createElement('div');
+        wrapper.classList.add('video-wrap');
+        video.parentNode.insertBefore( wrapper, video );
+        wrapper.appendChild( video );
+    } )
+});

--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -1,6 +1,9 @@
 // Styles.
 import '../styles/main.scss'
 
+// Common
+import './common/video-embeds.js'
+
 // Imports.
 import $ from 'jquery' // eslint-disable-line
 import 'bootstrap'

--- a/assets/styles/common/_video-embeds.scss
+++ b/assets/styles/common/_video-embeds.scss
@@ -1,0 +1,18 @@
+.video-wrap {
+  position: relative;
+  padding-bottom: 56.25%;
+  padding-top: 25px;
+  height: 0;
+  overflow: hidden;
+  max-width: 100%;
+
+  iframe,
+  object,
+  embed {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+}

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -10,6 +10,7 @@
 @import "common/tinymce";
 @import "common/wordpress";
 @import "common/cookie-notice";
+@import "common/video-embeds";
 
 // ****************
 // Component styles


### PR DESCRIPTION
WP has pretty good embed system for content areas. Problem arises when the embedded youtube/vimeo iframes have set width & height. 

This overrides the defaults to make video containers responsive in relation to their parent container.