### PR TITLE
Feature/twig controller id methods

### DIFF
--- a/lib/Controllers/ArchivePageController.php
+++ b/lib/Controllers/ArchivePageController.php
@@ -71,4 +71,13 @@ class ArchivePageController extends ArchiveController {
 		return $template[0]->ID;
 
 	}
+
+	/**
+	 * Returns page id.
+	 *
+	 * @return int $id of archive page.
+	 */
+	public function get_id() {
+		return $this->get_context( 'page' )->id;
+	}
 }

--- a/lib/Controllers/Controller.php
+++ b/lib/Controllers/Controller.php
@@ -58,6 +58,16 @@ class Controller implements ControllerInterface {
 	}
 
 	/**
+	 * Return value from context array.
+	 *
+	 * @param string $key of context.
+	 * @return mixed $value of context.
+	 */
+	public function get_context( $key ) {
+		return $this->context[ $key ];
+	}
+
+	/**
 	 * Set templates of controller
 	 *
 	 * @param mixed $templates string or array of Twigs.

--- a/lib/Controllers/ControllerInterface.php
+++ b/lib/Controllers/ControllerInterface.php
@@ -23,6 +23,14 @@ interface ControllerInterface {
 	public function add_context( $key, $value );
 
 	/**
+	 * Return value from context array.
+	 *
+	 * @param string $key of context.
+	 * @return mixed $value of context.
+	 */
+	public function get_context( $key );
+
+	/**
 	 * Set templates of controller
 	 *
 	 * @param mixed $templates string or array.


### PR DESCRIPTION
- Add `get_context()` method to twig `Controller.`
- Add `get_id()` method to `ArchivePageController`.

Solves edge cases where we might need to access archive template id after the controller is initiated. Example:` get_field()` ACF function that might default to incorrect ID if we let it use globals. Now we can call `get_field( 'my_acf_stuff', $controller->get_id() );`