### PR TITLE
Feature/localize rest vars

### DIFF
--- a/assets/build/.eslintrc.js
+++ b/assets/build/.eslintrc.js
@@ -6,6 +6,7 @@ module.exports = {
   ],
   'globals': {
     'wp': true,
+    'WPAPI': true,
   },
   'env': {
     'node': true,

--- a/assets/scripts/examples/ajax_request.js
+++ b/assets/scripts/examples/ajax_request.js
@@ -1,0 +1,23 @@
+import axios from 'axios'
+
+const ajaxurl = WPAPI.ajax_url
+
+/**
+ * Perform AJAX request to example endpoint/action.
+ */
+const request = async ( data ) => {
+
+  const params = new URLSearchParams()
+  params.append('action', 'your_action_name')
+  params.append('data', data)
+
+  // Note: WPAPI.ajax_nonce is not on by default.
+  // params.append('nonce', WPAPI.ajax_nonce)
+
+  // Send request
+  const response = await axios.post(ajaxurl, params )
+
+  return response
+}
+
+export default { request }

--- a/assets/scripts/examples/rest_request.js
+++ b/assets/scripts/examples/rest_request.js
@@ -1,0 +1,19 @@
+import axios from 'axios'
+
+/**
+ * Baseurl defined in plugin level.
+ */
+const baseUrl = WPAPI.rest_url + 'yourNamespace/example'
+
+/**
+ * Perform GET request to /example/ endpoint.
+ */
+const get = async () => {  
+
+  // Send request
+  const response = await axios.get(baseUrl)
+  
+  return response.data
+}
+
+export default { get }

--- a/assets/scripts/examples/rest_with_auth.js
+++ b/assets/scripts/examples/rest_with_auth.js
@@ -1,0 +1,19 @@
+import axios from 'axios'
+
+/**
+ * Baseurl defined in plugin level.
+ */
+const baseUrl = WPAPI.rest_url + 'yourNamespace/example'
+
+/**
+ * Perform GET request to /example/ endpoint.
+ */
+const get = async () => {
+
+  // Send request, append REST Nonce.
+  const response = await axios.get(baseUrl, { headers: {'X-WP-Nonce': WPAPI.rest_nonce} })
+
+  return response.data
+}
+
+export default { get }

--- a/lib/Assets.php
+++ b/lib/Assets.php
@@ -56,6 +56,17 @@ class Assets {
 		// Enqueue main scripts / styles.
 		wp_enqueue_style( 'pixels/main.css', $this->get_asset_path( 'styles/main.scss' ), false, null );
 		wp_enqueue_script( 'pixels/main.js', $this->get_asset_path( 'scripts/main.js' ), [ 'jquery' ], null, true );
+
+		// Localize nonces & urls for REST and/or AJAX.
+		wp_localize_script(
+			'pixels/main.js',
+			'WPAPI',
+			array(
+				'rest_nonce' => wp_create_nonce( 'wp_rest' ),
+				'rest_url'   => get_rest_url(),
+				'ajax_url'   => admin_url( 'admin-ajax.php' ),
+			)
+		);
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@babel/preset-env": "^7.7.6",
     "@babel/preset-react": "^7.7.4",
     "autoprefixer": "^9.7.3",
+    "axios": "^0.19.1",
     "babel-eslint": "^10.0.3",
     "babel-loader": "^8.0.6",
     "browser-sync": "^2.26.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1288,6 +1288,13 @@ axios@0.19.0:
     follow-redirects "1.5.10"
     is-buffer "^2.0.2"
 
+axios@^0.19.1:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.1.tgz#8a6a04eed23dfe72747e1dd43c604b8f1677b5aa"
+  integrity sha512-Yl+7nfreYKaLRvAvjNPkvfjnQHJM1yLBY3zhqAwcJSwR/6ETkanUgylgtIvkvz0xJ+p/vZuNw8X7Hnb7Whsbpw==
+  dependencies:
+    follow-redirects "1.5.10"
+
 babel-eslint@^10.0.3:
   version "10.0.3"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.3.tgz#81a2c669be0f205e19462fed2482d33e4687a88a"


### PR DESCRIPTION
Makes theme more ready for frontend -> backend communication using JS.

- Localize common variables for REST and/or AJAX (rest url, rest nonce, ajax url). Access them from global `WPAPI` variable in JS.
- Add Axios as frontend HTTP client
- Add code snippets / examples on common request in scripts/examples. Examples already use proper variable names for urls & nonces.
