### PR TITLE
Feature/webpack url loader support

### DIFF
--- a/assets/build/webpack.config.js
+++ b/assets/build/webpack.config.js
@@ -50,6 +50,14 @@ module.exports = (env, argv) =>  ({
                 ],
             },
             {
+              test: /\.(png|jpg|gif|svg)$/i,
+              use: [
+                {
+                  loader: 'url-loader',
+                },
+              ],
+            },
+            {
                 test: /\.(sa|sc|c)ss$/,
                 include: path.resolve(__dirname, config.paths.src.styles),
                 use: [

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "lint": "npm run -s lint:scripts && npm run -s lint:styles",
     "lint:scripts": "eslint assets/scripts assets/build --config assets/build/.eslintrc.js",
     "lint:styles": "stylelint \"{assets/styles,views}/**/*.{css,sass,scss,sss,less}\" --config assets/build/.stylelintrc.js",
+    "fix:scripts": "eslint assets/scripts assets/build --fix --config assets/build/.eslintrc.js",
+    "fix:styles": "stylelint \"{assets/styles,views}/**/*.{css,sass,scss,sss,less}\" --fix --config assets/build/.stylelintrc.js",
     "test": "npm run -s lint"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test": "npm run -s lint"
   },
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">= 10.13.0"
   },
   "devDependencies": {
     "@babel/core": "^7.7.5",


### PR DESCRIPTION
Add Webpack support to importing images in JS.

Example:

```
// Import on top of app.
import Image from '../../images/linkedin.svg'

// Usage inside return/render.
<img src={Image} />
```

Will result in something like:
`<img src="data:image/svg+xml;base64,[BASE64 STRING OF IMAGE HERE]">`

This will also work for images that are outside `assets` directory. Images in assets are still automatically copied to `dist`, but imported images will just be converted to base64 string. So this will also work:

```
// Import image from dir other than asset/images
import Image2 from './otherpic.png'

// Usage inside return/render.
<img src={Image2} />
```