### PR TITLE
Webpack: give main.scss its own entrypoint

### DIFF
--- a/assets/build/webpack.config.js
+++ b/assets/build/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = (env, argv) =>  ({
     entry: {
         'scripts/main': path.resolve(__dirname, '../scripts/main.js'),
         'scripts/customizer': path.resolve(__dirname, '../scripts/customizer.js'),
+        'styles/main': path.resolve(__dirname, '../styles/main.scss'),
     },
     output: {
         path: path.resolve(__dirname, config.paths.dist.root),

--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -1,6 +1,3 @@
-// Styles.
-import '../styles/main.scss'
-
 // Common
 import './common/video-embeds.js'
 


### PR DESCRIPTION
Previous updates changed production build key in manifest for main scss file. Meant that dev mode asset manifest works, but production mode doesn't find css anymore due to wrong key.

Give SCSS their own entrypoint in Webpack to fix the issue.