### PR TITLE
refactored admin footer text filter

### DIFF
--- a/assets/config.js
+++ b/assets/config.js
@@ -1,6 +1,6 @@
 const config = {
   urls : {
-    devUrl: 'https://theme.local',
+    devUrl: 'https://startertheme.local',
     devHost : 'localhost',
     devPort: 3000,
   },

--- a/assets/images/share.svg
+++ b/assets/images/share.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" viewBox="0 0 25 25">
+    <path fill="#0062C5" fill-rule="evenodd" d="M20 20H6V6h7V4H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM15 4v2h3.59l-9.83 9.83 1.41 1.41L20 7.41V11h2V4h-7z"/>
+</svg>

--- a/lib/Admin/Config.php
+++ b/lib/Admin/Config.php
@@ -45,9 +45,11 @@ class Config {
 
 	/**
 	 * Change "Powered by WordPress" to "Crafted by Pixels"
+	 *
+	 * @param string $footer_text current admin panel footer text.
 	 */
-	public function change_admin_footer($footer_text) {
-		$footer_text = "<p>Crafted by <a href=\"https://pixels.fi\" rel=\"nofollow\" target=\"_blank\">Pixels</a></p>";
+	public function change_admin_footer( $footer_text ) {
+		$footer_text = '<p>Crafted by <a href="https://pixels.fi" rel="nofollow" target="_blank">Pixels</a></p>';
 		return $footer_text;
 	}
 }

--- a/lib/Admin/Config.php
+++ b/lib/Admin/Config.php
@@ -20,7 +20,7 @@ class Config {
 
 		// Filters & Actions.
 		add_action( 'admin_menu', array( $this, 'disable_admin_menus' ) );
-		add_filter( 'admin_footer_text', array( $this, 'change_admin_footer' ) );
+		add_filter( 'admin_footer_text', array( $this, 'change_admin_footer' ), 1, 99 );
 	}
 
 	/**
@@ -46,9 +46,8 @@ class Config {
 	/**
 	 * Change "Powered by WordPress" to "Crafted by Pixels"
 	 */
-	public function change_admin_footer() {
-		?>
-		<p>Crafted by <a href="https://pixels.fi" rel="nofollow" target="_blank">Pixels</a></p>
-		<?php
+	public function change_admin_footer($footer_text) {
+		$footer_text = "<p>Crafted by <a href=\"https://pixels.fi\" rel=\"nofollow\" target=\"_blank\">Pixels</a></p>";
+		return $footer_text;
 	}
 }


### PR DESCRIPTION
This one refactors filter for changing admin text from "Powered by WordPress" to "Crafted by Pixels." Changes:
- Number of accepted arguments set to 1;
- Parameter $footer_text added and then returned after contents of it changed which is how filter should work. Previous echo statement removed; 
- Priority of 99 set to prevent 3rd party plugins from overriding the filter.