### PR TITLE
Feature/better navigation registration

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -102,7 +102,7 @@ final class App {
 
 		// Templating.
 
-		$this->timber        = new Twig\Timber();
+		$this->timber        = new Twig\Timber( $this->navigations );
 		$this->routing       = new Templates\Routing();
 		$this->design_system = new Templates\DesignSystem();
 	}

--- a/lib/Navigations.php
+++ b/lib/Navigations.php
@@ -17,12 +17,44 @@ namespace Pixels\Theme;
 class Navigations {
 
 	/**
+	 * Stores registred menus
+	 *
+	 * @var array
+	 */
+	public $menus;
+
+	/**
 	 * Class constructor
 	 */
 	public function __construct() {
 
+		// Setup list of menus to use in theme.
+		$this->setup_menus();
+
 		// Actions.
-		add_action( 'after_setup_theme', array( $this, 'add_theme_navigations' ) );
+		add_action( 'after_setup_theme', array( $this, 'register_theme_navigations' ) );
+	}
+
+	/**
+	 * Setup array of menus in theme
+	 * --> Used to regiter menus
+	 * --> Used to automatically add menus to Context
+	 */
+	public function setup_menus() {
+		$this->menus = array(
+			'primary_nav' => __( 'Primary Menu', 'pixels-text-domain' ),
+			'mobile_nav'  => __( 'Mobile Menu', 'pixels-text-domain' ),
+			'footer_nav'  => __( 'Footer Menu', 'pixels-text-domain' ),
+		);
+	}
+
+	/**
+	 * Return array of menus for external use.
+	 *
+	 * @return array $this->menus of theme.
+	 */
+	public function get_menus() {
+		return $this->menus;
 	}
 
 	/**
@@ -30,13 +62,9 @@ class Navigations {
 	 *
 	 * @since 1.0
 	 */
-	public function add_theme_navigations() {
+	public function register_theme_navigations() {
 		register_nav_menus(
-			array(
-				'primary_nav' => __( 'Primary Menu', 'pixels-text-domain' ),
-				'mobile_nav'  => __( 'Mobile Menu', 'pixels-text-domain' ),
-				'footer_nav'  => __( 'Footer Menu', 'pixels-text-domain' ),
-			)
+			$this->get_menus()
 		);
 	}
 }

--- a/lib/Navigations.php
+++ b/lib/Navigations.php
@@ -17,7 +17,7 @@ namespace Pixels\Theme;
 class Navigations {
 
 	/**
-	 * Stores registred menus
+	 * Stores registered menus
 	 *
 	 * @var array
 	 */
@@ -37,7 +37,7 @@ class Navigations {
 
 	/**
 	 * Setup array of menus in theme
-	 * --> Used to regiter menus
+	 * --> Used to register menus
 	 * --> Used to automatically add menus to Context
 	 */
 	public function setup_menus() {

--- a/lib/Navigations.php
+++ b/lib/Navigations.php
@@ -42,9 +42,9 @@ class Navigations {
 	 */
 	public function setup_menus() {
 		$this->menus = array(
-			'primary_nav' => __( 'Primary Menu', 'pixels-text-domain' ),
-			'mobile_nav'  => __( 'Mobile Menu', 'pixels-text-domain' ),
-			'footer_nav'  => __( 'Footer Menu', 'pixels-text-domain' ),
+			'desktop' => __( 'Primary Menu', 'pixels-text-domain' ),
+			'mobile'  => __( 'Mobile Menu', 'pixels-text-domain' ),
+			'footer'  => __( 'Footer Menu', 'pixels-text-domain' ),
 		);
 	}
 

--- a/lib/Twig/Context.php
+++ b/lib/Twig/Context.php
@@ -104,7 +104,7 @@ class Context {
 			// Append items to context array.
 			$context['menu'][ $menu ] = is_object( $content ) ? $content->get_items() : $content;
 		endforeach;
-		
+
 		return $context;
 	}
 

--- a/lib/Twig/Context.php
+++ b/lib/Twig/Context.php
@@ -11,6 +11,7 @@ namespace Pixels\Theme\Twig;
 // Utilities.
 use Pixels\Theme\Utils\Common;
 
+
 /**
  * Context class
  *
@@ -19,12 +20,24 @@ use Pixels\Theme\Utils\Common;
 class Context {
 
 	/**
-	 * Class constructor
+	 * Navigations instance of theme.
+	 *
+	 * @var Navigations.
 	 */
-	public function __construct() {
+	public $navigations;
+
+	/**
+	 * Class constructor
+	 *
+	 * @param Navigations $navigations of theme.
+	 */
+	public function __construct( $navigations ) {
+
+		$this->navigations = $navigations;
 
 		// Actions.
 		add_filter( 'timber_context', array( $this, 'add_general_context' ) );
+		add_filter( 'timber_context', array( $this, 'add_menus_context' ) );
 
 		// Uncomment to automatically add all archive links to context.
 		// add_filter( 'timber_context', array( $this, 'add_archive_links_context' ) );.
@@ -57,19 +70,41 @@ class Context {
 		$context['textdomain'] = 'pixels-text-domain';
 
 		/**
-		 * Menus.
-		 */
-		$context['menu']['desktop'] = new \TimberMenu( 'primary_nav' );
-		$context['menu']['mobile']  = new \TimberMenu( 'mobile_nav' );
-		$context['menu']['footer']  = new \TimberMenu( 'footer_nav' );
-
-		/**
 		 * Privacy policy page, if it exists.
 		 */
 		if ( function_exists( 'get_privacy_policy_url' ) ) {
 			$context['privacy'] = get_privacy_policy_url();
 		}
 
+		return $context;
+	}
+
+	/**
+	 * Set up all theme menus in context
+	 * --> If menu has item, return items of Timber\Menu
+	 * --> If not, return empty array
+	 * Removes schenarios where WP defaults to wrong menus.
+	 *
+	 * @param array $context The Timber global context.
+	 * @return array $context that has been updated.
+	 */
+	public function add_menus_context( $context ) {
+
+		// Registered menus from Navigations class.
+		$menus = $this->navigations->get_menus();
+
+		/**
+		 * Loop menus to context.
+		 */
+		foreach ( $menus as $menu => $title ) :
+
+			// Check if menu is in use.
+			$content = has_nav_menu( $menu ) ? new \TimberMenu( $menu ) : array();
+
+			// Append items to context array.
+			$context['menu'][ $menu ] = is_object( $content ) ? $content->get_items() : $content;
+		endforeach;
+		
 		return $context;
 	}
 

--- a/lib/Twig/Timber.php
+++ b/lib/Twig/Timber.php
@@ -32,11 +32,13 @@ class Timber {
 
 	/**
 	 * Class constructor
+	 *
+	 * @param Navigations $navigations of theme.
 	 */
-	public function __construct() {
+	public function __construct( $navigations ) {
 
 		// Class instances.
-		$this->context   = new Context();
+		$this->context   = new Context( $navigations );
 		$this->functions = new Functions();
 
 		// Check that Timber is enabled.


### PR DESCRIPTION
Short version: from now on we only need to add new menus to one array in Navigations.php. They will be automatically hooked to Twig Context with some failsafes.

- Refactor Navigation class to serve registered navs for outside consumption
- Automatically add all registered nav menus to Context using Navigations instance
- If menu is registered but not in use / empty, return empty array. Default WP behavior is to return unrelated stuff, which can be annoying. This should ensure our menus are not showing unrelated items.