### PR TITLE
Fix/asset manifest ignores

### DIFF
--- a/assets/build/webpack.config.js
+++ b/assets/build/webpack.config.js
@@ -102,7 +102,7 @@ module.exports = (env, argv) =>  ({
       new ManifestPlugin(
         {
           fileName: 'manifest.json',
-          filter: (file) => !file.path.match(/\.svg|png|jpg|js.LICENSE.txt|js.LICENSE$/),
+          filter: (file) => !file.path.match(/\.svg|png|jpg|woff|woff2|js.LICENSE.txt|js.LICENSE$/),
         }
       ),
       new CopyWebpackPlugin([

--- a/assets/build/webpack.config.js
+++ b/assets/build/webpack.config.js
@@ -102,7 +102,7 @@ module.exports = (env, argv) =>  ({
       new ManifestPlugin(
         {
           fileName: 'manifest.json',
-          filter: (file) => !file.path.match(/\.svg|png|jpg|js.LICENSE$/),
+          filter: (file) => !file.path.match(/\.svg|png|jpg|js.LICENSE.txt|js.LICENSE$/),
         }
       ),
       new CopyWebpackPlugin([


### PR DESCRIPTION
Add more ignores to asset manifest.json creation.

- Ignore js.LICENCE.txt files. Lead to false positive attempt to enqueue licence files.
- Ignore font files. Fonts are not loaded through asset manifest.