### PR TITLE
Admin footer hook: change order of params. Fixes #93

### DIFF
--- a/lib/Admin/Config.php
+++ b/lib/Admin/Config.php
@@ -20,7 +20,7 @@ class Config {
 
 		// Filters & Actions.
 		add_action( 'admin_menu', array( $this, 'disable_admin_menus' ) );
-		add_filter( 'admin_footer_text', array( $this, 'change_admin_footer' ), 1, 99 );
+		add_filter( 'admin_footer_text', array( $this, 'change_admin_footer' ), 999, 1 );
 	}
 
 	/**


### PR DESCRIPTION
"Crafted by Pixels" text in wp-admin was overridden by pretty much any competing action, like the one added by Kinsta hosting. The priority & number of arguments were in incorrect order, change them to ensure our text is higher priority.