### PR TITLE
Compatibility: run Timber checks before theme classes are loaded

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -87,24 +87,26 @@ final class App {
 	public function __construct() {
 
 		// Check if environment matches requirements.
-		Utils\Compatibility::run_checks();
+		$compatible = Utils\Compatibility::run_checks();
 
-		/**
-		 * Instantiate class instances
-		 */
+		if ( $compatible ) :
+			/**
+			 * Instantiate class instances
+			 */
 
-		$this->config      = new Config();
-		$this->assets      = new Assets();
-		$this->navigations = new Navigations();
-		$this->images      = new Images();
-		$this->hooks       = new Hooks();
-		$this->widgets     = new Widgets();
+			$this->config      = new Config();
+			$this->assets      = new Assets();
+			$this->navigations = new Navigations();
+			$this->images      = new Images();
+			$this->hooks       = new Hooks();
+			$this->widgets     = new Widgets();
 
-		// Templating.
+			// Templating.
 
-		$this->timber        = new Twig\Timber( $this->navigations );
-		$this->routing       = new Templates\Routing();
-		$this->design_system = new Templates\DesignSystem();
+			$this->timber        = new Twig\Timber( $this->navigations );
+			$this->routing       = new Templates\Routing();
+			$this->design_system = new Templates\DesignSystem();
+		endif;
 	}
 }
 

--- a/lib/Twig/Timber.php
+++ b/lib/Twig/Timber.php
@@ -41,13 +41,9 @@ class Timber {
 		$this->context   = new Context( $navigations );
 		$this->functions = new Functions();
 
-		// Check that Timber is enabled.
-		if ( ! class_exists( 'Timber' ) ) {
-			add_action( 'admin_notices', array( $this, 'missing_timber_admin_notice' ) );
-			add_filter( 'template_include', array( $this, 'missing_timber_frontend_notice' ) );
-		} else {
-			add_action( 'init', array( $this, 'setup_timber_settings' ) );
-		}
+		// Timber setuo.
+		add_action( 'init', array( $this, 'setup_timber_settings' ) );
+
 	}
 
 	/**
@@ -63,22 +59,5 @@ class Timber {
 		* @var array
 		 */
 		\Timber::$dirname = array( 'views/layouts', 'views/components' );
-	}
-
-	/**
-	 * Output an admin notice warning about Timber plugin not activated.
-	 */
-	public function missing_timber_admin_notice() {
-		/* Translators: placeholders are URL to the plugin page. */
-		echo '<div class="error"><p>' . sprintf( esc_attr( __( 'Timber not activated. Make sure you activate the plugin in <a href="%1$s">%2$s</a>', 'pixels-text-domain' ) ), esc_url( admin_url( 'plugins.php#timber' ) ), esc_url( admin_url( 'plugins.php' ) ) ) . '</p></div>';
-	}
-
-	/**
-	 * Output a page on the frontend warning about Timber plugin not activated.
-	 *
-	 * @param string $template the path to the template.
-	 */
-	public function missing_timber_frontend_notice( $template ) {
-		wp_die( esc_attr( __( 'Oh no! You need to activate the Timber plugin before you can use this theme.', 'pixels-text-domain' ) ) );
 	}
 }

--- a/lib/Utils/Compatibility.php
+++ b/lib/Utils/Compatibility.php
@@ -33,33 +33,77 @@ class Compatibility {
 
 	/**
 	 * Run all checks on theme start
+	 *
+	 * @return bool $compatible status.
 	 */
 	public static function run_checks() {
-		self::check_php_version();
-		self::check_wordpress_version();
+		$compatible =
+		self::check_php_version()
+		&& self::check_wordpress_version()
+		&& self::check_timber_plugin();
+
+		return $compatible;
 	}
 
 	/**
 	 * Ensure compatible version of PHP is used
 	 *
+	 * @return bool $compatible status;
 	 * @since 1.0
 	 */
 	public static function check_php_version() {
+
+		$compatible = true;
+
 		if ( version_compare( self::PHP_VERSION, phpversion(), '>=' ) ) {
 			// phpcs:ignore
 			wp_die( esc_attr( __( 'You must be using PHP ' . self::PHP_VERSION . ' or greater.', 'pixels-text-domain' ) ), esc_attr( __( 'Theme &rsaquo; Error', 'pixels-text-domain' ) ) );
+
+			$compatible = false;
 		}
+
+		return $compatible;
 	}
 
 	/**
 	 * Ensure compatible version of WordPress is used
 	 *
+	 * @return bool $compatible status;
 	 * @since 1.0
 	 */
 	public static function check_wordpress_version() {
+
+		$compatible = true;
+
 		if ( version_compare( self::WP_VERSION, get_bloginfo( 'version' ), '>=' ) ) {
 			// phpcs:ignore
 			wp_die( esc_attr( __( 'You must be using WordPress ' . self::WP_VERSION . ' or greater.', 'pixels-text-domain' ) ), esc_attr( __( 'Theme &rsaquo; Error', 'pixels-text-domain' ) ) );
+
+			$compatible = false;
 		}
+
+		return $compatible;
+	}
+
+	/**
+	 * Ensure Timber plugin is in use
+	 *
+	 * @return bool $compatible status;
+	 */
+	public static function check_timber_plugin() {
+
+		$compatible = true;
+
+		if ( ! class_exists( 'Timber' ) ) :
+			if ( is_admin() ) :
+				echo '<div class="error"><p>' . esc_attr( __( 'Timber not activated. Make sure you activate the plugin', 'pixels-text-domain' ) ) . '</p></div>';
+			else :
+				wp_die( esc_attr( __( 'Oh no! You need to activate the Timber plugin before you can use this theme.', 'pixels-text-domain' ) ) );
+			endif;
+
+			$compatible = false;
+		endif;
+
+		return $compatible;
 	}
 }


### PR DESCRIPTION
Previous setup allowed theme to include Timber-dependent code without Timber plugin. Checks were run too late, which lead to site being unaccessable.

- Run Timber related checks with common WP & PHP version checks
- Die() in frontend, add error notice in WP Admin. Still allows people to activate the plugin