### PR TITLE
added fluid type mixin

### DIFF
--- a/assets/styles/common/_typography.scss
+++ b/assets/styles/common/_typography.scss
@@ -8,6 +8,7 @@ body {
   font-family: $font-body;
 
   //Or set with fluid typography mixin
+  // NOTE: Mixin parameters should be provided using same units as $breakpoint-min and $breakpoint-max. For example, if there breakpoints are set in rems then mixin should receive values in rems.
   // @include fluid-type($body-font-size-mobile, $body-font-size, 0, 0);
 }
 

--- a/assets/styles/common/_typography.scss
+++ b/assets/styles/common/_typography.scss
@@ -6,6 +6,9 @@ body {
   font-weight: $body-font-weight-mobile;
   color: $color-body;
   font-family: $font-body;
+
+  //Or set with fluid typography mixin
+  // @include fluid-type($body-font-size-mobile, $body-font-size, 0, 0);
 }
 
 h1,
@@ -29,6 +32,9 @@ h1,
   line-height: $h1-line-height-mobile;
   letter-spacing: $h1-letter-spacing-mobile;
   font-weight: $h1-font-weight-mobile;
+
+  //Or set with fluid typography mixin
+  // @include fluid-type($h1-font-size-mobile, $h1-font-size, $h1-margin-bottom-mobile, $h1-margin-bottom);
 }
 
 h2,

--- a/assets/styles/common/_variables.scss
+++ b/assets/styles/common/_variables.scss
@@ -14,6 +14,7 @@ $font-body:           "Helvetica Neue", Helvetica, Arial, sans-serif;
 $font-heading:        "Helvetica Neue", Helvetica, Arial, sans-serif;
 
 // Typography breakpoints
+// NOTE: These are crucial for fluid-type mixin.
 $breakpoint-min: 20rem;
 $breakpoint-max: 75rem;
 

--- a/assets/styles/common/_variables.scss
+++ b/assets/styles/common/_variables.scss
@@ -13,6 +13,10 @@ $color-link-hover: #000;
 $font-body:           "Helvetica Neue", Helvetica, Arial, sans-serif;
 $font-heading:        "Helvetica Neue", Helvetica, Arial, sans-serif;
 
+// Typography breakpoints
+$breakpoint-min: 20rem;
+$breakpoint-max: 75rem;
+
 /* #################################### */
 
 // Body styles mobile

--- a/assets/styles/common/mixins/_fluid-type.scss
+++ b/assets/styles/common/mixins/_fluid-type.scss
@@ -2,6 +2,8 @@
   @return $value / ($value * 0 + 1);
 }
 
+// NOTE: Mixin parameters should be provided using same units as $breakpoint-min and $breakpoint-max. For example, if there breakpoints are set in rems then mixin should receive values in rems.
+
 @mixin fluid-type($min-font-size, $max-font-size, $min-margin-bottom: 0, $max-margin-bottom: 0, $min-vw: $breakpoint-min, $max-vw: $breakpoint-max) {
   $u1: unit($min-vw);
   $u2: unit($max-vw);

--- a/assets/styles/common/mixins/_fluid-type.scss
+++ b/assets/styles/common/mixins/_fluid-type.scss
@@ -1,0 +1,29 @@
+@function strip-unit($value) {
+  @return $value / ($value * 0 + 1);
+}
+
+@mixin fluid-type($min-font-size, $max-font-size, $min-margin-bottom: 0, $max-margin-bottom: 0, $min-vw: $breakpoint-min, $max-vw: $breakpoint-max) {
+  $u1: unit($min-vw);
+  $u2: unit($max-vw);
+  $u3: unit($min-font-size);
+  $u4: unit($max-font-size);
+  $u5: unit($min-margin-bottom);
+  $u6: unit($max-margin-bottom);
+
+  @if $u1 == $u2 and $u1 == $u3 and $u1 == $u4 and $u1 == $u5 and $u1 == $u6 {
+    & {
+      font-size: $min-font-size !important;
+      margin-bottom: $min-margin-bottom !important;
+
+      @media (min-width: $min-vw) {
+        font-size: calc(#{$min-font-size} + #{strip-unit($max-font-size - $min-font-size)} * ((100vw - #{$min-vw}) / #{strip-unit($max-vw - $min-vw)})) !important;
+        margin-bottom: calc(#{$min-margin-bottom} + #{strip-unit($max-margin-bottom - $min-margin-bottom)} * ((100vw - #{$min-vw}) / #{strip-unit($max-vw - $min-vw)})) !important;
+      }
+
+      @media (min-width: $max-vw) {
+        font-size: $max-font-size !important;
+        margin-bottom: $max-margin-bottom !important;
+      }
+    }
+  }
+}

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -6,6 +6,7 @@
 // *************
 // Common styles
 // *************
+@import "common/mixins/fluid-type";
 @import "common/typography";
 @import "common/global";
 @import "common/buttons";


### PR DESCRIPTION
This PR introduces concept of fluid typography with a convenient mixin that accepts four parameters:
- minimum font size;
- maximum font size;
- minimum bottom margin;
- maximum bottom margin;

Also this PR adds new set of variables "Typography breakpoints": $breakpoint-min, $breakpoint-max. Variable $breakpoint-min defines viewport width under which font-sizes and typography margins stop changing and remain at minimum values. Variable $breakpoint-max defines viewport width ABOVE which same values stop changing and stick to maximum. Breakpoints must be defined with same units as margins and font sizes - rems.

In previous projects there was a problem with setting fonts between multiple breakpoints. Usually designers provide mobile and desktop values of font sizes and margins. Screen sizes in between were not really properly covered and I often saw weird font sizes and margins on iPad screen or landscape mobile screens. Of course this can be solved with writing more breakpoints but this mixin just does all the scaling automatically based on value of VW unit of the viewport which changes with the viewport width.
