### PR TITLE
PostController: add get_id() method

### DIFF
--- a/lib/Controllers/PostController.php
+++ b/lib/Controllers/PostController.php
@@ -36,4 +36,13 @@ class PostController extends Controller {
 	public function set_post( $post ) {
 		$this->add_context( 'post', $post );
 	}
+
+	/**
+	 * Returns post id.
+	 *
+	 * @return int $id of post.
+	 */
+	public function get_id() {
+		return $this->get_context( 'post' )->id;
+	}
 }


### PR DESCRIPTION
Occasionally ID of post in controller is needed afterwards. Add getter to access post id in controller props.