### PR TITLE
Feature/section classes and naming

### DIFF
--- a/views/components/section/section.twig
+++ b/views/components/section/section.twig
@@ -1,4 +1,4 @@
-<section class="section section-{{ section.acf_fc_layout }}">
+<section class="section section-{{ section.acf_fc_layout }} {% block section_classes %}{% endblock %}">
   {% block section_content %}
 
   {% endblock %}

--- a/views/layouts/template-sectioned/template-sectioned.twig
+++ b/views/layouts/template-sectioned/template-sectioned.twig
@@ -10,6 +10,6 @@
 
 {% block site_content %}
 	{% for section in sections %}
-		{% include 'section/section-' ~ section.acf_fc_layout ~ '.twig' ignore missing %}
-	{% endfor %}
+        {% include 'section/' ~ section.acf_fc_layout ~ '/' ~ section.acf_fc_layout ~ '.twig' ignore missing %}
+    {% endfor %}
 {% endblock %}


### PR DESCRIPTION
- Add `section_classes` block to allow adding classes in derivative sections
- Change "sections" folder structure.

**Before:**
```
section:
    -> section-foo.twig
    -> section-foo.sccs
    -> section-bar.twig
    -> section-bar.scss
    -> section-baz.twig
    -> section-baz.scss

```
etc.

**Now:**
```
section:
    -> bar:
        -> bar.twig
        -> bar.scss
    -> foo:
        -> foo.twig
        -> foo.scss
    -> baz:
        -> baz.twig
        -> baz.scss
```