### PR TITLE
Base: add wp_body_open hook.

### DIFF
--- a/views/layouts/base/base.twig
+++ b/views/layouts/base/base.twig
@@ -14,6 +14,8 @@
   {% endblock %}
 
   <body class="{{ body_class }}">
+    {{ function('wp_body_open') }}
+    
     {% block site_body %}
 
       {% block site_header %}


### PR DESCRIPTION
WP 5.2 added a hook for actions after body has opened. Add the hook to our base.twig.

Fixes #112