### PR TITLE
PHP linting: ignore comment rules

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -71,4 +71,12 @@
   <rule ref="WordPress.PHP.YodaConditions.NotYoda">
     <severity>0</severity>
   </rule>
+  <!-- Ignore comment rules -->
+  <rule ref="Squiz.Commenting">
+    <severity>0</severity>
+  </rule>
+  <!-- Trailing commas in function calls -->
+  <rule ref="PHPCompatibility.Syntax.NewFunctionCallTrailingComma.FoundInFunctionCall">
+    <severity>0</severity>
+  </rule>
 </ruleset>


### PR DESCRIPTION
Around 90% of reported “issues” were about how comments were written. That is irrelevant as far as code quality is concerned. All that fluff was hiding true issues.

Fixes #133 