### PR TITLE
Video embeds: pass found videos from main script

### DIFF
--- a/assets/scripts/common/video-embeds.js
+++ b/assets/scripts/common/video-embeds.js
@@ -1,8 +1,7 @@
 /**
  * Make video embeds responsive
  */
-export const makeEmbedsResponsive = () => {
-  const videos = document.querySelectorAll('iframe[src*="youtube"], iframe[src*="vimeo"]')
+export const makeEmbedsResponsive = (videos) => {
   videos.forEach((video) => {
     // Remove enforced height & width
     video.removeAttribute('height');

--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -6,9 +6,14 @@ import $ from 'jquery' // eslint-disable-line
 import 'bootstrap'
 
 const pixelsThemeApp = (function main() {
+  const handleResponsiveVideos = () => {
+    const videos = document.querySelectorAll('iframe[src*="youtube"], iframe[src*="vimeo"]')
+    makeEmbedsResponsive(videos)
+  }
+
   // Page load actions.
   const init = () => {
-    makeEmbedsResponsive()
+    handleResponsiveVideos()
   }
 
   // Scroll actions.
@@ -20,8 +25,6 @@ const pixelsThemeApp = (function main() {
   const resize = () => {
 
   }
-
-  /* Functions */
 
   // Exports to DOM binds.
   return { init, scroll, resize }


### PR DESCRIPTION
Moving video fetching inside responsiveEmbeds function fixed issue, but on second thought it might make more sense to still pass videos in as parameter. It keeps the function more "pure" and simpler to test. We just need to add the video fetching to main file.

- Add "videos" param back
- Fetch videos on main file, pass them to the function that makes them responsive