### PR TITLE
Fixes version comparison in check_wordpress_version()

### DIFF
--- a/lib/Utils/Compatibility.php
+++ b/lib/Utils/Compatibility.php
@@ -74,7 +74,7 @@ class Compatibility {
 
 		$compatible = true;
 
-		if ( version_compare( self::WP_VERSION, get_bloginfo( 'version' ), '>=' ) ) {
+		if ( version_compare( self::WP_VERSION, get_bloginfo( 'version' ), '<' ) ) {
 			// phpcs:ignore
 			wp_die( esc_attr( __( 'You must be using WordPress ' . self::WP_VERSION . ' or greater.', 'pixels-text-domain' ) ), esc_attr( __( 'Theme &rsaquo; Error', 'pixels-text-domain' ) ) );
 


### PR DESCRIPTION
Should now properly check that Wordpress is 5.5.0 or greater

this closes #160 