### PR TITLE
Add rem scss function

### DIFF
--- a/assets/styles/common/_typography.scss
+++ b/assets/styles/common/_typography.scss
@@ -96,7 +96,7 @@ h6,
 
   h1,
   .h1 {
-    font-size: rem($h1-font-size-tablet, $body-font-size-tablet);
+    font-size: rem-tablet($h1-font-size-tablet);
     line-height: $h1-line-height-tablet;
     letter-spacing: $h1-letter-spacing-tablet;
     font-weight: $h1-font-weight-tablet;
@@ -104,7 +104,7 @@ h6,
 
   h2,
   .h2 {
-    font-size: rem($h2-font-size-tablet, $body-font-size-tablet);
+    font-size: rem-tablet($h2-font-size-tablet);
     line-height: $h2-line-height-tablet;
     letter-spacing: $h2-letter-spacing-tablet;
     font-weight: $h2-font-weight-tablet;
@@ -112,7 +112,7 @@ h6,
 
   h3,
   .h3 {
-    font-size: rem($h3-font-size-tablet, $body-font-size-tablet);
+    font-size: rem-tablet($h3-font-size-tablet);
     line-height: $h3-line-height-tablet;
     letter-spacing: $h3-letter-spacing-tablet;
     font-weight: $h3-font-weight-tablet;
@@ -120,7 +120,7 @@ h6,
 
   h4,
   .h4 {
-    font-size: rem($h4-font-size-tablet, $body-font-size-tablet);
+    font-size: rem-tablet($h4-font-size-tablet);
     line-height: $h4-line-height-tablet;
     letter-spacing: $h4-letter-spacing-tablet;
     font-weight: $h4-font-weight-tablet;
@@ -128,7 +128,7 @@ h6,
 
   h5,
   .h5 {
-    font-size: rem($h5-font-size-tablet, $body-font-size-tablet);
+    font-size: rem-tablet($h5-font-size-tablet);
     line-height: $h5-line-height-tablet;
     letter-spacing: $h5-letter-spacing-tablet;
     font-weight: $h5-font-weight-tablet;
@@ -136,14 +136,14 @@ h6,
 
   h6,
   .h6 {
-    font-size: rem($h6-font-size-tablet, $body-font-size-tablet);
+    font-size: rem-tablet($h6-font-size-tablet);
     line-height: $h6-line-height-tablet;
     letter-spacing: $h6-letter-spacing-tablet;
     font-weight: $h6-font-weight-tablet;
   }
 
   .lead {
-    font-size: rem($lead-font-size, $body-font-size-tablet);
+    font-size: rem-tablet($lead-font-size);
     line-height: $lead-line-height;
     letter-spacing: $lead-letter-spacing;
     font-weight: $lead-font-weight;
@@ -161,7 +161,7 @@ h6,
 
   h1,
   .h1 {
-    font-size: rem($h1-font-size, $body-font-size);
+    font-size: rem-desktop($h1-font-size);
     line-height: $h1-line-height;
     letter-spacing: $h1-letter-spacing;
     font-weight: $h1-font-weight;
@@ -169,7 +169,7 @@ h6,
 
   h2,
   .h2 {
-    font-size: rem($h2-font-size, $body-font-size);
+    font-size: rem-desktop($h2-font-size);
     line-height: $h2-line-height;
     letter-spacing: $h2-letter-spacing;
     font-weight: $h2-font-weight;
@@ -177,7 +177,7 @@ h6,
 
   h3,
   .h3 {
-    font-size: rem($h3-font-size, $body-font-size);
+    font-size: rem-desktop($h3-font-size);
     line-height: $h3-line-height;
     letter-spacing: $h3-letter-spacing;
     font-weight: $h3-font-weight;
@@ -185,7 +185,7 @@ h6,
 
   h4,
   .h4 {
-    font-size: rem($h4-font-size, $body-font-size);
+    font-size: rem-desktop($h4-font-size);
     line-height: $h4-line-height;
     letter-spacing: $h4-letter-spacing;
     font-weight: $h4-font-weight;
@@ -193,7 +193,7 @@ h6,
 
   h5,
   .h5 {
-    font-size: rem($h5-font-size, $body-font-size);
+    font-size: rem-desktop($h5-font-size);
     line-height: $h5-line-height;
     letter-spacing: $h5-letter-spacing;
     font-weight: $h5-font-weight;
@@ -201,7 +201,7 @@ h6,
 
   h6,
   .h6 {
-    font-size: rem($h6-font-size, $body-font-size);
+    font-size: rem-desktop($h6-font-size);
     line-height: $h6-line-height;
     letter-spacing: $h6-letter-spacing;
     font-weight: $h6-font-weight;

--- a/assets/styles/common/_typography.scss
+++ b/assets/styles/common/_typography.scss
@@ -29,7 +29,7 @@ h6,
 
 h1,
 .h1 {
-  font-size: $h1-font-size-mobile;
+  font-size: rem($h1-font-size-mobile);
   line-height: $h1-line-height-mobile;
   letter-spacing: $h1-letter-spacing-mobile;
   font-weight: $h1-font-weight-mobile;
@@ -40,7 +40,7 @@ h1,
 
 h2,
 .h2 {
-  font-size: $h2-font-size-mobile;
+  font-size: rem($h2-font-size-mobile);
   line-height: $h2-line-height-mobile;
   letter-spacing: $h2-letter-spacing-mobile;
   font-weight: $h2-font-weight-mobile;
@@ -48,7 +48,7 @@ h2,
 
 h3,
 .h3 {
-  font-size: $h3-font-size-mobile;
+  font-size: rem($h3-font-size-mobile);
   line-height: $h3-line-height-mobile;
   letter-spacing: $h3-letter-spacing-mobile;
   font-weight: $h3-font-weight-mobile;
@@ -56,7 +56,7 @@ h3,
 
 h4,
 .h4 {
-  font-size: $h4-font-size-mobile;
+  font-size: rem($h4-font-size-mobile);
   line-height: $h4-line-height-mobile;
   letter-spacing: $h4-letter-spacing-mobile;
   font-weight: $h4-font-weight-mobile;
@@ -64,7 +64,7 @@ h4,
 
 h5,
 .h5 {
-  font-size: $h5-font-size-mobile;
+  font-size: rem($h5-font-size-mobile);
   line-height: $h5-line-height-mobile;
   letter-spacing: $h5-letter-spacing-mobile;
   font-weight: $h5-font-weight-mobile;
@@ -72,14 +72,14 @@ h5,
 
 h6,
 .h6 {
-  font-size: $h6-font-size-mobile;
+  font-size: rem($h6-font-size-mobile);
   line-height: $h6-line-height-mobile;
   letter-spacing: $h6-letter-spacing-mobile;
   font-weight: $h6-font-weight-mobile;
 }
 
 .lead {
-  font-size: $lead-font-size-mobile;
+  font-size: rem($lead-font-size-mobile);
   line-height: $lead-line-height-mobile;
   letter-spacing: $lead-letter-spacing-mobile;
   font-weight: $lead-font-weight-mobile;
@@ -96,7 +96,7 @@ h6,
 
   h1,
   .h1 {
-    font-size: $h1-font-size-tablet;
+    font-size: rem($h1-font-size-tablet, $body-font-size-tablet);
     line-height: $h1-line-height-tablet;
     letter-spacing: $h1-letter-spacing-tablet;
     font-weight: $h1-font-weight-tablet;
@@ -104,7 +104,7 @@ h6,
 
   h2,
   .h2 {
-    font-size: $h2-font-size-tablet;
+    font-size: rem($h2-font-size-tablet, $body-font-size-tablet);
     line-height: $h2-line-height-tablet;
     letter-spacing: $h2-letter-spacing-tablet;
     font-weight: $h2-font-weight-tablet;
@@ -112,7 +112,7 @@ h6,
 
   h3,
   .h3 {
-    font-size: $h3-font-size-tablet;
+    font-size: rem($h3-font-size-tablet, $body-font-size-tablet);
     line-height: $h3-line-height-tablet;
     letter-spacing: $h3-letter-spacing-tablet;
     font-weight: $h3-font-weight-tablet;
@@ -120,7 +120,7 @@ h6,
 
   h4,
   .h4 {
-    font-size: $h4-font-size-tablet;
+    font-size: rem($h4-font-size-tablet, $body-font-size-tablet);
     line-height: $h4-line-height-tablet;
     letter-spacing: $h4-letter-spacing-tablet;
     font-weight: $h4-font-weight-tablet;
@@ -128,7 +128,7 @@ h6,
 
   h5,
   .h5 {
-    font-size: $h5-font-size-tablet;
+    font-size: rem($h5-font-size-tablet, $body-font-size-tablet);
     line-height: $h5-line-height-tablet;
     letter-spacing: $h5-letter-spacing-tablet;
     font-weight: $h5-font-weight-tablet;
@@ -136,14 +136,14 @@ h6,
 
   h6,
   .h6 {
-    font-size: $h6-font-size-tablet;
+    font-size: rem($h6-font-size-tablet, $body-font-size-tablet);
     line-height: $h6-line-height-tablet;
     letter-spacing: $h6-letter-spacing-tablet;
     font-weight: $h6-font-weight-tablet;
   }
 
   .lead {
-    font-size: $lead-font-size;
+    font-size: rem($lead-font-size, $body-font-size-tablet);
     line-height: $lead-line-height;
     letter-spacing: $lead-letter-spacing;
     font-weight: $lead-font-weight;
@@ -161,7 +161,7 @@ h6,
 
   h1,
   .h1 {
-    font-size: $h1-font-size;
+    font-size: rem($h1-font-size, $body-font-size);
     line-height: $h1-line-height;
     letter-spacing: $h1-letter-spacing;
     font-weight: $h1-font-weight;
@@ -169,7 +169,7 @@ h6,
 
   h2,
   .h2 {
-    font-size: $h2-font-size;
+    font-size: rem($h2-font-size, $body-font-size);
     line-height: $h2-line-height;
     letter-spacing: $h2-letter-spacing;
     font-weight: $h2-font-weight;
@@ -177,7 +177,7 @@ h6,
 
   h3,
   .h3 {
-    font-size: $h3-font-size;
+    font-size: rem($h3-font-size, $body-font-size);
     line-height: $h3-line-height;
     letter-spacing: $h3-letter-spacing;
     font-weight: $h3-font-weight;
@@ -185,7 +185,7 @@ h6,
 
   h4,
   .h4 {
-    font-size: $h4-font-size;
+    font-size: rem($h4-font-size, $body-font-size);
     line-height: $h4-line-height;
     letter-spacing: $h4-letter-spacing;
     font-weight: $h4-font-weight;
@@ -193,7 +193,7 @@ h6,
 
   h5,
   .h5 {
-    font-size: $h5-font-size;
+    font-size: rem($h5-font-size, $body-font-size);
     line-height: $h5-line-height;
     letter-spacing: $h5-letter-spacing;
     font-weight: $h5-font-weight;
@@ -201,7 +201,7 @@ h6,
 
   h6,
   .h6 {
-    font-size: $h6-font-size;
+    font-size: rem($h6-font-size, $body-font-size);
     line-height: $h6-line-height;
     letter-spacing: $h6-letter-spacing;
     font-weight: $h6-font-weight;

--- a/assets/styles/common/_variables.scss
+++ b/assets/styles/common/_variables.scss
@@ -27,43 +27,43 @@ $body-letter-spacing-mobile:   normal;
 $body-font-weight-mobile:      normal;
 
 // H1 styles mobile
-$h1-font-size-mobile:          2.5rem;
+$h1-font-size-mobile:          40px;
 $h1-line-height-mobile:        1.5;
 $h1-letter-spacing-mobile:     0;
 $h1-font-weight-mobile:        bold;
 
 // H2 styles mobile
-$h2-font-size-mobile:          2rem;
+$h2-font-size-mobile:          32px;
 $h2-line-height-mobile:        1.5;
 $h2-letter-spacing-mobile:     0;
 $h2-font-weight-mobile:        bold;
 
 // H3 styles mobile
-$h3-font-size-mobile:          1.75rem;
+$h3-font-size-mobile:          28px;
 $h3-line-height-mobile:        1.5;
 $h3-letter-spacing-mobile:     0;
 $h3-font-weight-mobile:        bold;
 
 // H4 styles mobile
-$h4-font-size-mobile:          1.5rem;
+$h4-font-size-mobile:          24px;
 $h4-line-height-mobile:        1.5;
 $h4-letter-spacing-mobile:     0;
 $h4-font-weight-mobile:        bold;
 
 // H5 styles mobile
-$h5-font-size-mobile:          1.25rem;
+$h5-font-size-mobile:          20px;
 $h5-line-height-mobile:        1.5;
 $h5-letter-spacing-mobile:     0;
 $h5-font-weight-mobile:        bold;
 
 // H6 styles mobile
-$h6-font-size-mobile:          1rem;
+$h6-font-size-mobile:          16;
 $h6-line-height-mobile:        1;
 $h6-letter-spacing-mobile:     0;
 $h6-font-weight-mobile:        bold;
 
 // Lead text mobile
-$lead-font-size-mobile:        1.1rem;
+$lead-font-size-mobile:        17.6;
 $lead-line-height-mobile:      1.5;
 $lead-letter-spacing-mobile:   0;
 $lead-font-weight-mobile:      normal;
@@ -77,37 +77,37 @@ $body-letter-spacing-tablet:   normal;
 $body-font-weight-tablet:      normal;
 
 // H1 styles tablet
-$h1-font-size-tablet:          2.5rem;
+$h1-font-size-tablet:          40px;
 $h1-line-height-tablet:        1.5;
 $h1-letter-spacing-tablet:     0;
 $h1-font-weight-tablet:        bold;
 
 // H2 styles tablet
-$h2-font-size-tablet:          2rem;
+$h2-font-size-tablet:          32px;
 $h2-line-height-tablet:        1.5;
 $h2-letter-spacing-tablet:     0;
 $h2-font-weight-tablet:        bold;
 
 // H3 styles tablet
-$h3-font-size-tablet:          1.75rem;
+$h3-font-size-tablet:          28px;
 $h3-line-height-tablet:        1.5;
 $h3-letter-spacing-tablet:     0;
 $h3-font-weight-tablet:        bold;
 
 // H4 styles tablet
-$h4-font-size-tablet:          1.5rem;
+$h4-font-size-tablet:          24px;
 $h4-line-height-tablet:        1.5;
 $h4-letter-spacing-tablet:     0;
 $h4-font-weight-tablet:        bold;
 
 // H5 styles tablet
-$h5-font-size-tablet:          1.25rem;
+$h5-font-size-tablet:          20px;
 $h5-line-height-tablet:        1.5;
 $h5-letter-spacing-tablet:     0;
 $h5-font-weight-tablet:        bold;
 
 // H6 styles tablet
-$h6-font-size-tablet:          1rem;
+$h6-font-size-tablet:          16px;
 $h6-line-height-tablet:        1;
 $h6-letter-spacing-tablet:     0;
 $h6-font-weight-tablet:        bold;
@@ -121,37 +121,37 @@ $body-letter-spacing:   normal;
 $body-font-weight:      normal;
 
 // H1 styles desktop
-$h1-font-size:          2.5rem;
+$h1-font-size:          40px;
 $h1-line-height:        1.5;
 $h1-letter-spacing:     0;
 $h1-font-weight:        bold;
 
 // H2 styles desktop
-$h2-font-size:          2rem;
+$h2-font-size:          32px;
 $h2-line-height:        1.5;
 $h2-letter-spacing:     0;
 $h2-font-weight:        bold;
 
 // H3 styles desktop
-$h3-font-size:          1.75rem;
+$h3-font-size:          28px;
 $h3-line-height:        1.5;
 $h3-letter-spacing:     0;
 $h3-font-weight:        bold;
 
 // H4 styles desktop
-$h4-font-size:          1.5rem;
+$h4-font-size:          24px;
 $h4-line-height:        1.5;
 $h4-letter-spacing:     0;
 $h4-font-weight:        bold;
 
 // H5 styles desktop
-$h5-font-size:          1.25rem;
+$h5-font-size:          20px;
 $h5-line-height:        1.5;
 $h5-letter-spacing:     0;
 $h5-font-weight:        bold;
 
 // H6 styles desktop
-$h6-font-size:          1rem;
+$h6-font-size:          16px;
 $h6-line-height:        1;
 $h6-letter-spacing:     0;
 $h6-font-weight:        bold;
@@ -159,7 +159,7 @@ $h6-font-weight:        bold;
 /* #################################### */
 
 // Lead text
-$lead-font-size:        1.1rem;
+$lead-font-size:        17.6;
 $lead-line-height:      1.5;
 $lead-letter-spacing:   0;
 $lead-font-weight:      normal;

--- a/assets/styles/common/_variables.scss
+++ b/assets/styles/common/_variables.scss
@@ -57,13 +57,13 @@ $h5-letter-spacing-mobile:     0;
 $h5-font-weight-mobile:        bold;
 
 // H6 styles mobile
-$h6-font-size-mobile:          16;
+$h6-font-size-mobile:          16px;
 $h6-line-height-mobile:        1;
 $h6-letter-spacing-mobile:     0;
 $h6-font-weight-mobile:        bold;
 
 // Lead text mobile
-$lead-font-size-mobile:        17.6;
+$lead-font-size-mobile:        17.6px;
 $lead-line-height-mobile:      1.5;
 $lead-letter-spacing-mobile:   0;
 $lead-font-weight-mobile:      normal;
@@ -159,7 +159,7 @@ $h6-font-weight:        bold;
 /* #################################### */
 
 // Lead text
-$lead-font-size:        17.6;
+$lead-font-size:        17.6px;
 $lead-line-height:      1.5;
 $lead-letter-spacing:   0;
 $lead-font-weight:      normal;

--- a/assets/styles/common/functions/_rem.scss
+++ b/assets/styles/common/functions/_rem.scss
@@ -6,3 +6,12 @@
 @function rem($px, $body: $body-font-size-mobile) {
   @return ($px / $body) + rem;
 }
+
+// Shorthands for above function, add/edit/remove depending on needed breakpoints for the project
+@function rem-tablet($px) {
+  @return rem($px, $body-font-size-tablet);
+}
+
+@function rem-desktop($px) {
+  @return rem($px, $body-font-size);
+}

--- a/assets/styles/common/functions/_rem.scss
+++ b/assets/styles/common/functions/_rem.scss
@@ -1,0 +1,8 @@
+/// Computes rem for given pixel value. Passed in parameters can be numbers (f.e. 16, 24.5) or pixel strings (f.e. 16px)
+///
+/// @param  {number|string} $px   - Pixel value we want to convert to rem
+/// @param  {number|string} $body - Optional pixel value of root element's font-size. This can be changed f.e. in media queries, if font-size changes
+/// @return {string}              - Computed value as rem unit
+@function rem($px, $body: $body-font-size-mobile) {
+  @return ($px / $body) + rem;
+}

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -7,6 +7,7 @@
 // Common styles
 // *************
 @import "common/mixins/fluid-type";
+@import "common/functions/rem";
 @import "common/typography";
 @import "common/global";
 @import "common/buttons";


### PR DESCRIPTION
Helps developers convert pixel units to rem units.

This is usually needed when starting new project, where we setup typographies for the codebase. Typographies are defined in Figma as pixels, so it is tiresome and can cause human errors when we do rem convertions manually to each text-style. Also tweaking or debugging hardcoded rems can take time when we need to convert them back to pixels.

This function can also be used where we would usually use pixels. Here are few examples:

```
.site-footer {
  padding: rem(80);
}

@media (min-width: 768px) {
  .site-footer {
    padding: rem(80, $body-font-size-tablet);
  }
}
``` 

--- 

Update:
Added shorthands for desktop and tablet use, so in .scss-files we don't need to remember variable names for base font-sizes.

Examples:
```
@media (min-width: 768px) {
  .site-footer {
    padding: rem-tablet(80);
  }
}
@media (min-width: 992px) {
  .site-footer {
    padding: rem-desktop(120);
  }
}
```