### PR TITLE
Cypress tests: add retries

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,5 @@
 {
+  "retries": 4,
   "fixturesFolder": "tests/Integration/config/fixtures",
   "integrationFolder": "tests/Integration/tests",
   "pluginsFile": "tests/Integration/config/plugins/index.js",


### PR DESCRIPTION
Make cypress run tests up to 5 times, should they fail in the first place.

This is to cover scenarios that should work, but wont on that particular second. Could be things like server, network or other connection issues that at first mark the test failed.

Fixes #169