### PR TITLE
CodeSniffer: exlude rule about WP capitalization

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -79,4 +79,8 @@
   <rule ref="PHPCompatibility.Syntax.NewFunctionCallTrailingComma.FoundInFunctionCall">
     <severity>0</severity>
   </rule>
+  <!-- Ignore spelling of wordpress -->
+  <rule ref="WordPress.WP.CapitalPDangit.Misspelled">
+    <severity>0</severity>
+  </rule>  
 </ruleset>


### PR DESCRIPTION
Disable spelling rule of "WordPress". No need to get lint warning about non-functional branding thing.

Fixes #170 