### PR TITLE
add TimberImage mock function to setupTests

### DIFF
--- a/setupTests.js
+++ b/setupTests.js
@@ -23,6 +23,16 @@ Twig.extendFunction('responsive_image', (id, mobileImage, desktopImage) => `prin
 Twig.extendFunction('responsive_background', (id, mobileImage, desktopImage, selector) => `printed background image of id ${id} and sizes ${mobileImage} & ${desktopImage} with selector ${selector}`)
 
 /**
+ * Mock TimberImage
+ */
+Twig.extendFunction('TimberImage', (id) => {
+  return {
+    src: `src for timber image with id ${id}`,
+    alt: `alt-text for timber image with id ${id}`
+  }
+})
+
+/**
   * Mock social share function calls.
   */
 Twig.extendFunction('facebook_share', () => 'https://facebook-share-link.dev')


### PR DESCRIPTION
This change lets us test twig files that use `TimberImage()`

this closes #218