### PR TITLE
Add icons namespace to twig

### DIFF
--- a/lib/Twig/Timber.php
+++ b/lib/Twig/Timber.php
@@ -83,7 +83,7 @@ class Timber {
 	 */
 	public function register_namespaces( $loader ) {
 		$loader->addPath( __DIR__ . '/../../views/components', 'components' );
-		$loader->addPath( __DIR__ . '/../..//views/layouts', 'layouts' );
+		$loader->addPath( __DIR__ . '/../../views/layouts', 'layouts' );
 		$loader->addPath( __DIR__ . '/../../assets/images', 'icons' );
 
 		return $loader;

--- a/lib/Twig/Timber.php
+++ b/lib/Twig/Timber.php
@@ -84,6 +84,7 @@ class Timber {
 	public function register_namespaces( $loader ) {
 		$loader->addPath( __DIR__ . '/../../views/components', 'components' );
 		$loader->addPath( __DIR__ . '/../..//views/layouts', 'layouts' );
+		$loader->addPath( __DIR__ . '/../../assets/images', 'icons' );
 
 		return $loader;
 	}

--- a/setupTests.js
+++ b/setupTests.js
@@ -7,6 +7,7 @@ import { Twig } from 'twig-testing-library'
 global.twigNamespaces = {
   components: './views/components',
   layouts: './views/layouts',
+  icons: './assets/images',
 }
 
 /**


### PR DESCRIPTION
This needed to be added to both php and js to cover both development and testing environments. With this change we can append svg-files to twig-files with following syntax:

```
<div>
    {% include "@icons/facebook.svg" %}
</div>
```

This of course means that assets needs to be in the defined folder

 this closes #221 