### PR TITLE
add gradient transparency fixer plugin to postcss conf

### DIFF
--- a/assets/build/postcss.config.js
+++ b/assets/build/postcss.config.js
@@ -1,8 +1,9 @@
 /* eslint-disable */
 
-const postcssNormalize 	= require('postcss-normalize')
-const autoprefixer 		= require('autoprefixer')
-const cssnano 			= require('cssnano')
+const postcssNormalize = require('postcss-normalize')
+const autoprefixer = require('autoprefixer')
+const cssnano = require('cssnano')
+const gradientTransparencyFix = require('postcss-gradient-transparency-fix')
 
 module.exports = {
 	plugins: [
@@ -10,8 +11,9 @@ module.exports = {
 		postcssNormalize(),
 		cssnano(
 			{
-	            preset: 'default',
-	        }
-        )
+				preset: 'default',
+			}
+		),
+		gradientTransparencyFix()
 	]
 }

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "node-sass": "^5.0.0",
     "postcss": "^8.2.12",
     "postcss-clean": "^1.1.0",
+    "postcss-gradient-transparency-fix": "^4.0.0",
     "postcss-loader": "^5.2.0",
     "postcss-normalize": "^9.0.0",
     "react-test-renderer": "^17.0.1",
@@ -99,7 +100,6 @@
     "cypress-axe": "^0.12.0",
     "jquery": "^3.4.1",
     "popper.js": "^1.16.1",
-    "postcss-gradient-transparency-fix": "^4.0.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "cypress-axe": "^0.12.0",
     "jquery": "^3.4.1",
     "popper.js": "^1.16.1",
+    "postcss-gradient-transparency-fix": "^4.0.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3356,7 +3356,7 @@ color-name@^1.0.0, color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-color-string@^1.5.4:
+color-string@^1.5.0, color-string@^1.5.4:
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.5.tgz#65474a8f0e7439625f3d27a6a19d89fc45223014"
   integrity sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==
@@ -3364,7 +3364,7 @@ color-string@^1.5.4:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
 
-color@^3.1.1:
+color@^3.0.0, color@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/color/-/color-3.1.3.tgz#ca67fb4e7b97d611dcde39eceed422067d91596e"
   integrity sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==
@@ -7875,6 +7875,16 @@ postcss-discard-overridden@^5.0.0:
   resolved "https://registry.yarnpkg.com/postcss-discard-overridden/-/postcss-discard-overridden-5.0.0.tgz#ac00f695a60001eda52135a11fac87376b8da9ee"
   integrity sha512-hybnScTaZM2iEA6kzVQ6Spozy7kVdLw+lGw8hftLlBEzt93uzXoltkYp9u0tI8xbfhxDLTOOzHsHQCkYdmzRUg==
 
+postcss-gradient-transparency-fix@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-gradient-transparency-fix/-/postcss-gradient-transparency-fix-4.0.0.tgz#5c05bccc9428ec742cfcdbe8848f906100605aac"
+  integrity sha512-y75SiNrfFr11vuzKfSKRlhZdcxtudwNyHzoRSJ8hr9rStN5/4L6M9X1JfaTGZgQ9d1eNDPbgAvi3j6CFrhTE2w==
+  dependencies:
+    color "^3.0.0"
+    color-string "^1.5.0"
+    postcss "^7.0.0"
+    postcss-value-parser "^4.0.0"
+
 postcss-html@^0.36.0:
   version "0.36.0"
   resolved "https://registry.yarnpkg.com/postcss-html/-/postcss-html-0.36.0.tgz#b40913f94eaacc2453fd30a1327ad6ee1f88b204"
@@ -8153,7 +8163,7 @@ postcss-unique-selectors@^5.0.0:
     postcss-selector-parser "^6.0.2"
     uniqs "^2.0.0"
 
-postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0:
+postcss-value-parser@^4.0.0, postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
   integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
@@ -8167,7 +8177,7 @@ postcss@^6.x:
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
-postcss@^7, postcss@^7.0.14, postcss@^7.0.2, postcss@^7.0.21, postcss@^7.0.26, postcss@^7.0.27, postcss@^7.0.32, postcss@^7.0.35, postcss@^7.0.6:
+postcss@^7, postcss@^7.0.0, postcss@^7.0.14, postcss@^7.0.2, postcss@^7.0.21, postcss@^7.0.26, postcss@^7.0.27, postcss@^7.0.32, postcss@^7.0.35, postcss@^7.0.6:
   version "7.0.35"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.35.tgz#d2be00b998f7f211d8a276974079f2e92b970e24"
   integrity sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==


### PR DESCRIPTION
This fixes issue when we try to create gradient css which goes from color to transparent. In Safari this transparent color is defined in OS which is gray for some reason.

Tested this with few examples, you can see results in gist below.
https://gist.github.com/AttLii/2181af115493114f26dd0561f99a723a

this closes #223